### PR TITLE
Front-end packaging improvements

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,4 @@
+> 0.5% and last 3 versions
+Firefox ESR
+ie 11
+not OperaMini all

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,4 +8,13 @@ We welcome all support, whether on bug reports, code, design, reviews, tests, do
 
 ### Installation
 
-TODO: Add instructions.
+With Python 3.7 or up, Node 16, and [pre-commit](https://pre-commit.com/),
+
+```bash
+git clone git@github.com:kbayliss/tbxforms.git
+cd tbxforms/
+poetry install
+pre-commit install
+npm install
+npm run build
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,5 @@
 BSD 2-Clause License
 
-This software was originally adapted from https://github.com/wildfish/crispy-forms-gds (Author: Wildfish Ltd. <rolo@wildfish.com>)
-
 Copyright (c) 2021-current Torchbox Ltd.
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npm install tbxforms
 Instantiate your forms:
 
 ```javascript
-import TbxForms from '@tbxforms/tbxforms';
+import TbxForms from 'tbxforms';
 
 document.addEventListener('DOMContentLoaded', () => {
     for (const form of document.querySelectorAll(TbxForms.selector())) {
@@ -73,10 +73,21 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 ```
 
-Import the styles into your project:
+Import the styles into your project, either as CSS:
 
-```sass
-@import 'node_modules/@tbxforms/tbxforms/static/sass/tbxforms';
+```scss
+// Either as CSS without any customisations:
+@use 'node_modules/tbxforms/style.css';
+```
+
+Or as Sass, to customise variables:
+
+```scss
+// Or as Sass, with variables to customise:
+@use 'node_modules/tbxforms/tbxforms.scss' with (
+    $tbxforms-error-colour: #f00,
+    $tbxforms-text-colour: #000,
+);
 ```
 
 ## Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,16 +5,13 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "tbxforms",
             "version": "0.0.0",
-            "license": "UNLICENSED",
-            "dependencies": {
-                "sass": "^1.38.2"
-            },
+            "license": "BSD-2-Clause",
             "devDependencies": {
                 "autoprefixer": "^10.2.5",
                 "eslint": "^7.26.0",
                 "prettier": "2.3.2",
+                "sass": "^1.39.0",
                 "vite": "^2.2.3"
             }
         },
@@ -159,6 +156,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
             "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+            "dev": true,
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -213,6 +211,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -231,6 +230,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
             "dependencies": {
                 "fill-range": "^7.0.1"
             },
@@ -319,6 +319,7 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
             "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+            "dev": true,
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -910,6 +911,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -940,6 +942,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
             "hasInstallScript": true,
             "optional": true,
             "os": [
@@ -985,6 +988,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -1076,6 +1080,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
             "dependencies": {
                 "binary-extensions": "^2.0.0"
             },
@@ -1099,6 +1104,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1116,6 +1122,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -1127,6 +1134,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -1257,6 +1265,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1336,6 +1345,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
             "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -1410,6 +1420,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -1467,9 +1478,10 @@
             }
         },
         "node_modules/sass": {
-            "version": "1.38.2",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.38.2.tgz",
-            "integrity": "sha512-Bz1fG6qiyF0FX6m/I+VxtdVKz1Dfmg/e9kfDy2PhWOkq3T384q2KxwIfP0fXpeI+EyyETdOauH+cRHQDFASllA==",
+            "version": "1.39.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.39.0.tgz",
+            "integrity": "sha512-F4o+RhJkNOIG0b6QudYU8c78ZADKZjKDk5cyrf8XTKWfrgbtyVVXImFstJrc+1pkQDCggyidIOytq6gS4gCCZg==",
+            "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0"
             },
@@ -1594,6 +1606,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -1806,6 +1819,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
             "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+            "dev": true,
             "requires": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -1843,7 +1857,8 @@
         "binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "dev": true
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -1859,6 +1874,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
             "requires": {
                 "fill-range": "^7.0.1"
             }
@@ -1920,6 +1936,7 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
             "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+            "dev": true,
             "requires": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -2369,6 +2386,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
@@ -2389,6 +2407,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
             "optional": true
         },
         "function-bind": {
@@ -2421,6 +2440,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
             "requires": {
                 "is-glob": "^4.0.1"
             }
@@ -2490,6 +2510,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
             "requires": {
                 "binary-extensions": "^2.0.0"
             }
@@ -2506,7 +2527,8 @@
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
         },
         "is-fullwidth-code-point": {
             "version": "3.0.0",
@@ -2518,6 +2540,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
@@ -2525,7 +2548,8 @@
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
@@ -2634,7 +2658,8 @@
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true
         },
         "normalize-range": {
             "version": "0.1.2",
@@ -2695,7 +2720,8 @@
         "picomatch": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+            "dev": true
         },
         "postcss": {
             "version": "8.3.6",
@@ -2742,6 +2768,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
             "requires": {
                 "picomatch": "^2.2.1"
             }
@@ -2778,9 +2805,10 @@
             }
         },
         "sass": {
-            "version": "1.38.2",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.38.2.tgz",
-            "integrity": "sha512-Bz1fG6qiyF0FX6m/I+VxtdVKz1Dfmg/e9kfDy2PhWOkq3T384q2KxwIfP0fXpeI+EyyETdOauH+cRHQDFASllA==",
+            "version": "1.39.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.39.0.tgz",
+            "integrity": "sha512-F4o+RhJkNOIG0b6QudYU8c78ZADKZjKDk5cyrf8XTKWfrgbtyVVXImFstJrc+1pkQDCggyidIOytq6gS4gCCZg==",
+            "dev": true,
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0"
             }
@@ -2871,6 +2899,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
             "requires": {
                 "is-number": "^7.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     },
     "scripts": {
         "format": "prettier --write '**/?(.)*.{md,mdx,css,scss,js,json,json5,yaml,yml}'",
-        "build": "npm run-script format && vite build && cp -R tbxforms/static/sass/* dist/",
+        "build": "vite build && cp -R tbxforms/static/sass/* dist/",
+        "prepublishOnly": "npm run build -s",
         "report:package": "npm pack --loglevel notice 2>&1 >/dev/null | sed -e 's/^npm notice //' && rm *.tgz"
     }
 }

--- a/package.json
+++ b/package.json
@@ -32,14 +32,12 @@
         "autoprefixer": "^10.2.5",
         "eslint": "^7.26.0",
         "prettier": "2.3.2",
+        "sass": "^1.39.0",
         "vite": "^2.2.3"
     },
     "scripts": {
         "format": "prettier --write '**/?(.)*.{md,mdx,css,scss,js,json,json5,yaml,yml}'",
         "build": "npm run-script format && vite build",
         "report:package": "npm pack --loglevel notice 2>&1 >/dev/null | sed -e 's/^npm notice //' && rm *.tgz"
-    },
-    "dependencies": {
-        "sass": "^1.38.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "module": "./dist/tbxforms.es.js",
     "files": [
         "dist/*.js",
-        "dist/*.css"
+        "dist/*.css",
+        "dist/**/*.scss"
     ],
     "description": "A Torchbox-flavoured template pack for django-crispy-forms, adapted from crispy-forms-gds",
     "author": "Kyle Bayliss",
@@ -37,7 +38,7 @@
     },
     "scripts": {
         "format": "prettier --write '**/?(.)*.{md,mdx,css,scss,js,json,json5,yaml,yml}'",
-        "build": "npm run-script format && vite build",
+        "build": "npm run-script format && vite build && cp -R tbxforms/static/sass/* dist/",
         "report:package": "npm pack --loglevel notice 2>&1 >/dev/null | sed -e 's/^npm notice //' && rm *.tgz"
     }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "description": "A Torchbox-flavoured template pack for django-crispy-forms, adapted from crispy-forms-gds",
     "author": "Kyle Bayliss",
     "private": false,
-    "license": "UNLICENSED",
+    "license": "BSD-2-Clause",
     "repository": {
         "type": "git",
         "url": "https://github.com/kbayliss/tbxforms.git"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    plugins: {
+        autoprefixer: {},
+    },
+};

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A Torchbox-flavoured template pack for django-crispy-forms, adapt
 authors = [
     "Kyle Bayliss <kyle.bayliss@torchbox.com>"
 ]
-license = "BSD-3-Clause"
+license = "BSD-2-Clause"
 readme = "README.md"
 homepage = ""
 repository = "https://github.com/kbayliss/tbxforms/"


### PR DESCRIPTION
Some small cleanup here and there (licensing), and more importantly further setup for the front-end package. I believe this should be ready to `npm publish`.

One thing still missing is IE11 support with the JS – I think we have to decide whether this is needed or not. We’d need to stop using syntax that esbuild can’t transpile to ES5, change the build target to ES5, and document any needed polyfill (`element.closest`, `NodeList.forEach`).